### PR TITLE
real student preferences are now schedule items

### DIFF
--- a/scripts/yankee_swap.py
+++ b/scripts/yankee_swap.py
@@ -1,11 +1,11 @@
-from fair.allocation import general_yankee_swap_E
-from fair.metrics import utilitarian_welfare
+from fair.allocation import general_yankee_swap_E, round_robin
+from fair.metrics import utilitarian_welfare, nash_welfare
 
 import qsurvey
 
 SPARSE = False
 
-survey_file = "resources/survey_data.csv"
+survey_file = "resources/random_survey.csv"
 schedule_file = "resources/anonymized_courses.xlsx"
 mapping_file = "resources/survey_column_mapping.csv"
 
@@ -31,5 +31,9 @@ students = [
     student for student in students if len(student.student.preferred_courses) > 0
 ]
 
-X = general_yankee_swap_E(students, schedule)
-print("YS utilitarian welfare: ", utilitarian_welfare(X[0], students, schedule))
+# X = general_yankee_swap_E(students, schedule)
+# print("YS utilitarian welfare: ", utilitarian_welfare(X[0], students, schedule))
+# print("YS nash welfare: ", nash_welfare(X[0], students, schedule))
+
+X = round_robin(students, schedule)
+print("RR utilitarian welfare: ", utilitarian_welfare(X, students, schedule))

--- a/src/qsurvey/__init__.py
+++ b/src/qsurvey/__init__.py
@@ -257,8 +257,8 @@ class QSurvey:
         statuses = []
         for _, row in self.df.iterrows():
             preferred = [
-                course_map[crs]["course num"]
-                for crs in all_courses
+                schedule[j]
+                for j, crs in enumerate(all_courses)
                 if not np.isnan(row[crs]) and row[crs] > 1
             ]
             total_num_courses = row["3"]


### PR DESCRIPTION
Changed generation of real students (not synthetic students yet). preferred_courses used to be a list of strings, it is now a list of ScheduleItems as it was supposed to be (matching the strings). The problem is that now the allocation algorithms don't run correctly: RR and YS don't allocate any items. Will try ILP too. I'm guessing there is probably something wrong with the definition of the constraints when generating the students. Will keep looking into it, any ideas or guidance would be appreciated. 